### PR TITLE
chore: update dependencies and add prerequisite step for execution

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -25,6 +25,18 @@ You will need
 - a Download ZIP of this repository, see the [Code] button in the top right and unpack it.
 - Open the project via the `pom.xml` in your IDE.
 - Check you can do a maven install of the root project (on the right in IntelliJ)
+- Set VM Options of your run configurations to open necessary modules (see also [blog post on Java 17 support](https://chronicle.software/chronicle-support-java-17/)):
+```
+--add-exports=java.base/jdk.internal.ref=ALL-UNNAMED
+--add-exports=java.base/sun.nio.ch=ALL-UNNAMED
+--add-exports=jdk.unsupported/sun.misc=ALL-UNNAMED
+--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED
+--add-opens=jdk.compiler/com.sun.tools.javac=ALL-UNNAMED
+--add-opens=java.base/java.lang=ALL-UNNAMED
+--add-opens=java.base/java.lang.reflect=ALL-UNNAMED
+--add-opens=java.base/java.io=ALL-UNNAMED
+--add-opens=java.base/java.util=ALL-UNNAMED
+```
 
 === Stack Traces
 

--- a/pom.xml
+++ b/pom.xml
@@ -22,11 +22,10 @@
     <parent>
         <groupId>net.openhft</groupId>
         <artifactId>java-parent-pom</artifactId>
-        <version>1.1.24</version>
+        <version>1.26.0</version>
         <relativePath/>
     </parent>
 
-    <groupId>net.openhft</groupId>
     <artifactId>puzzles-parent</artifactId>
     <version>2.20.1</version>
     <name>OpenHFT/Puzzles</name>
@@ -43,13 +42,13 @@
                 <groupId>net.openhft</groupId>
                 <artifactId>third-party-bom</artifactId>
                 <type>pom</type>
-                <version>3.19.4</version>
+                <version>3.26.0</version>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>net.openhft</groupId>
                 <artifactId>chronicle-bom</artifactId>
-                <version>2.21ea-SNAPSHOT</version>
+                <version>2.26ea47</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
As described in title. Dependencies were outdated and steps to execute this on a modern JVM were missing.